### PR TITLE
Don't run configure and ignore some build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ autom4te.cache
 config.log
 config.status
 mtpfs
+compile
+depcomp
+install-sh
+missing

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
 aclocal
 autoconf
 automake -a
-./configure --enable-debug
+#./configure --enable-debug


### PR DESCRIPTION
Don't configure, people may have "out-of-source-tree" builds:

Normally you do:
```
./configure --foo-bar
make
```

This is common but however does mess up the source tree with build files. You can easily separate it from each other:

```
mkdir build
cd build
../configure --foo-bar
```

Now all build (object files, Makefile files, et cetera) stay out of the source code tree and don't mix with it anymore.
