### PR TITLE
Don't interrupt reading folder if no sub-folder is found

### DIFF
--- a/mtpfs.c
+++ b/mtpfs.c
@@ -942,8 +942,6 @@ mtpfs_readdir (const gchar * path, void *buf, fuse_fill_dir_t filler,
 	return_unlock (0);
       folder = folder->child;
     }
-  if (folder == NULL)
-    return_unlock (0);
 
   while (folder != NULL)
     {


### PR DESCRIPTION
Fixes #22. If no sub-folder is found the go further and continue listing files in folder.
