### PR TITLE
fix function returning non-void warning

### DIFF
--- a/mtpfs.c
+++ b/mtpfs.c
@@ -1625,6 +1625,7 @@ int
 mtpfs_blank ()
 {
   // Do nothing
+  return 0;
 }
 
 static struct fuse_operations mtpfs_oper = {


### PR DESCRIPTION
../mtpfs.c: In function 'mtpfs_blank':
../mtpfs.c:1628:1: warning: no return statement in function returning non-void [-Wreturn-type]
 1628 | }
      | ^